### PR TITLE
ci: update railway start command to use default port

### DIFF
--- a/le-backend/railway.toml
+++ b/le-backend/railway.toml
@@ -2,7 +2,7 @@
 builder = "NIXPACKS"
 
 [deploy]
-startCommand = "uvicorn app.main:app --host 0.0.0.0 --port $PORT"
+startCommand = "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8090}"
 healthcheckPath = "/api/v1/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
Use ${PORT:-8090} syntax to provide a default port when $PORT is not set